### PR TITLE
Add: 現在地取得ボタン周辺の説明

### DIFF
--- a/app/javascript/google_maps.js
+++ b/app/javascript/google_maps.js
@@ -7,12 +7,14 @@ function initMap() {
     streetViewControl: false,
     fullscreenControl: false,
   });
+  /////////////////// ここで現在地取得ボタンを設定 ///////////////////
   // 位置情報取得ボタンを作成
   const locationButton = document.createElement("button");
   // const locationButton = document.getElementById("locationButton");
   locationButton.textContent = "現在地へ移動";
   locationButton.classList.add("custom-map-control-button");
   map.controls[google.maps.ControlPosition.TOP_RIGHT].push(locationButton);
+  // 位置情報取得ボタンクリックで発火
   locationButton.addEventListener("click", () => {
     console.log(window.event.keyCode);
     console.log(window.event.which);
@@ -36,6 +38,7 @@ function initMap() {
       }
     }
   });
+  ////////////////////////////////////////////////////////////////
 
   // 検索ボックスを作成
   const input = document.getElementById("pac-input");

--- a/app/javascript/google_maps.js
+++ b/app/javascript/google_maps.js
@@ -10,7 +10,6 @@ function initMap() {
   /////////////////// ここで現在地取得ボタンを設定 ///////////////////
   // 位置情報取得ボタンを作成
   const locationButton = document.createElement("button");
-  // const locationButton = document.getElementById("locationButton");
   locationButton.textContent = "現在地へ移動";
   locationButton.classList.add("custom-map-control-button");
   map.controls[google.maps.ControlPosition.TOP_RIGHT].push(locationButton);
@@ -19,23 +18,18 @@ function initMap() {
     console.log(window.event.keyCode);
     console.log(window.event.which);
     event.preventDefault();
-    if (window.event.keyCode === 13) {
-      console.log('geolocationEnterKey確認');
-      return false
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        (position) => {
+          const pos = {
+            lat: position.coords.latitude,
+            lng: position.coords.longitude,
+          };
+          map.setCenter(pos);
+        },
+      );
     } else {
-      if (navigator.geolocation) {
-        navigator.geolocation.getCurrentPosition(
-          (position) => {
-            const pos = {
-              lat: position.coords.latitude,
-              lng: position.coords.longitude,
-            };
-            map.setCenter(pos);
-          },
-        );
-      } else {
-        return false
-      }
+      return false
     }
   });
   ////////////////////////////////////////////////////////////////
@@ -52,7 +46,6 @@ function initMap() {
   // 検索で発火
   searchBox.addListener("places_changed", () => {
     const places = searchBox.getPlaces();
-
     if (places.length == 0) {
       return;
     }

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -14,3 +14,12 @@ import '@fortawesome/fontawesome-free/js/all'
 import '../stylesheets/application'
 import '../stylesheets/google_maps'
 import '../stylesheets/simple_calendar_custom';
+
+// エンターキーによるsubmitを無効化
+$(document).ready(function () {
+  $('.ignore-enterkey').keypress(function (e) {
+    if (!e) var e = window.event;
+    if (e.keyCode == 13)
+      return false;
+  });
+});

--- a/app/views/shared/_map.html.slim
+++ b/app/views/shared/_map.html.slim
@@ -1,6 +1,6 @@
 .map_wrapper
   div#map
-  input id="pac-input" class="controls" type="text" placeholder="Search Box"
+  input id="pac-input" class=%i[controls ignore-enterkey] type="text" placeholder="Search Box"
 
 - google_api_place = "https://maps.googleapis.com/maps/api/js?key=#{ Rails.application.credentials.api_key[:google_maps] }&libraries=places&callback=initMap".html_safe
 script{ async src = google_api_place }

--- a/app/views/temporary_schedules/new.html.slim
+++ b/app/views/temporary_schedules/new.html.slim
@@ -8,11 +8,11 @@
           .form-group
             = render 'shared/map'
             h5.mt-1 出発地点
-            = f.text_field :start_point_name, id: "data-start-point-name", placeholder: "マップから選択して下さい", size: "100x100", readonly: true, class: "form-control"
+            = f.text_field :start_point_name, id: "data-start-point-name", placeholder: "マップから選択して下さい", size: "100x100", readonly: true, class: "form-control ignore-enterkey"
             = f.text_field :start_point_lat_lng, id: "data-start-point-location", type: "hidden"
             = f.text_field :start_point_address, id: "data-start-point-address", type: "hidden"
             h5.mt-1 待ち合わせ場所
-            = f.text_field :destination_name, id: "data-destination-name", placeholder: "マップから選択して下さい", size: "100x100", readonly: true, class: "form-control"
+            = f.text_field :destination_name, id: "data-destination-name", placeholder: "マップから選択して下さい", size: "100x100", readonly: true, class: "form-control ignore-enterkey"
             = f.text_field :destination_lat_lng, id: "data-destination-location", type: "hidden"
             = f.text_field :destination_address, id: "data-destination-address", type: "hidden"
           .form-group.text-center


### PR DESCRIPTION
#  概要
クリックイベントがエンターキーで発火されるので、無効化したい。

# 現状（発生している問題）
対象ファイル：
app/javascript/google_maps.js
https://github.com/yshici/late-hack/blob/f561930fe10ef384a9f7dcdff094fd2e25f387cd/app/javascript/google_maps.js
app/views/temporary_schedules/new.html.slim
https://github.com/yshici/late-hack/blob/761d61ee280bb0e35f7b9d2111d3d97b13ec73a3/app/views/temporary_schedules/new.html.slim
app/views/shared/_map.html.slim
https://github.com/yshici/late-hack/blob/master/app/views/shared/_map.html.slim
google maps Javascript APIを使用して表示したマップ上に現在地取得ボタンを生成し、クリックイベントを設定。
ページ上の他のフォームでエンターキーを押すと、現在地取得ボタンのクリックイベントが発火されるため、それを無効化したい。
`locationButton.addEventListener`内の
`console.log(window.event.keyCode)`はUndefined、
`console.log(window.event.which)`は1となる。
クリックしたと認識されている？？

# 試したこと
エンターキー押下を確認すると処理しない条件分岐を書いたが、window.event.keyCodeがUndefinedとなる。
```
if (window.event.keyCode === 13) {
      return false
} 
```
# 補足
javascriptの書き方の問題なのか、map APIの独自の関数？が影響しているのか切り分けできていないです。
現在地取得ボタンのaddEventListenerの書き方が おかしい or 大丈夫そう、だけでも見て頂きたいです！
