### PR TITLE
Add latetime column

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -3,8 +3,15 @@ class ResultsController < ApplicationController
     @schedule = current_user.schedules.find(params[:id])
     # Jsに渡す変数
     gon.latlng = [[@schedule.destination_lat,@schedule.destination_lng],[@schedule.start_point_lat,@schedule.start_point_lng]]
-    gon.excuse = @schedule.excuse_schedules.map do |excuse_schedule|
+    select_excuses = @schedule.excuse_schedules.map do |excuse_schedule|
       Excuse.find(excuse_schedule.excuse_id)
     end
+    gon.excuse = select_excuses
+    # 遅刻時間の合計算出して時間・分に変換
+    late_times = 0
+    select_excuses.each do |select_excuse|
+      late_times += select_excuse.late_time
+    end
+    @late_time = Time.at(late_times*60).utc.strftime('%-H時間%-M分')
   end
 end

--- a/app/controllers/temporary_schedules_controller.rb
+++ b/app/controllers/temporary_schedules_controller.rb
@@ -22,7 +22,15 @@ class TemporarySchedulesController < ApplicationController
     @latlng << TemporarySchedule.new().adjust_latlng(@schedule["start_point_lat_lng"])
     gon.latlng = @latlng
     @api_info = ApiGet.new().get_api.merge(ApiGet.new().get_api_with_position(@latlng[0][0], @latlng[0][1]))
-    gon.excuse = Excuse.find(Excuse.pluck(:id).shuffle[0..2])
+    # 言い訳をランダムで3つ取ってくる
+    select_excuses = Excuse.find(Excuse.pluck(:id).shuffle[0..2])
+    gon.excuse = select_excuses
+    # 遅刻時間の合計算出して時間・分に変換
+    late_times = 0
+    select_excuses.each do |select_excuse|
+      late_times += select_excuse.late_time
+    end
+    @late_time = Time.at(late_times*60).utc.strftime('%-H時間%-M分')
   end
 
   private

--- a/app/dashboards/excuse_dashboard.rb
+++ b/app/dashboards/excuse_dashboard.rb
@@ -12,6 +12,7 @@ class ExcuseDashboard < Administrate::BaseDashboard
     schedules: Field::HasMany,
     id: Field::Number,
     content: Field::String,
+    late_time: Field::Number,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
   }.freeze
@@ -26,6 +27,7 @@ class ExcuseDashboard < Administrate::BaseDashboard
   schedules
   id
   content
+  late_time
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
@@ -35,6 +37,7 @@ class ExcuseDashboard < Administrate::BaseDashboard
   schedules
   id
   content
+  late_time
   created_at
   updated_at
   ].freeze
@@ -46,6 +49,7 @@ class ExcuseDashboard < Administrate::BaseDashboard
   excuse_schedules
   schedules
   content
+  late_time
   ].freeze
 
   # COLLECTION_FILTERS

--- a/app/models/excuse.rb
+++ b/app/models/excuse.rb
@@ -1,5 +1,6 @@
 class Excuse < ApplicationRecord
   validates :content, presence: true, uniqueness: true, length: { maximum: 255 }
+  validates :late_time, presence: true
 
   has_many :excuse_schedules
   has_many :schedules, through: :excuse_schedules

--- a/app/views/shared/_result.html.slim
+++ b/app/views/shared/_result.html.slim
@@ -7,7 +7,7 @@ h3.pt-3.border-bottom.border-gray 診断結果
       h6
         | 道中でいろんなことが起こりました。
         br
-        | ３時間遅刻できます。
+        | #{@late_time}遅刻できます。
       h6.text-danger#map-error
     = render 'shared/map_routes'
     //////// 天気情報と番組表は一旦使わない //////

--- a/db/fixtures/excuses.rb
+++ b/db/fixtures/excuses.rb
@@ -1,44 +1,53 @@
-Excuse.seed_once(
+Excuse.seed(
   id: 1,
-  content: '財布を落としました!'
+  content: '財布を落としました',
+  late_time: 60
 )
 
-Excuse.seed_once(
+Excuse.seed(
   id: 2,
-  content: '携帯を無くしました'
+  content: '携帯を無くしました',
+  late_time: 60
 )
 
-Excuse.seed_once(
+Excuse.seed(
   id: 3,
-  content: 'お腹が痛くなりました'
+  content: 'お腹が痛くなりました',
+  late_time: 30
 )
 
-Excuse.seed_once(
+Excuse.seed(
   id: 4,
-  content: 'お婆ちゃんを助けていました'
+  content: 'お婆ちゃんを助けていました',
+  late_time: 90
 )
 
-Excuse.seed_once(
+Excuse.seed(
   id: 5,
-  content: '拾った財布を交番に届けました'
+  content: '拾った財布を交番に届けました',
+  late_time: 30
 )
 
-Excuse.seed_once(
+Excuse.seed(
   id: 6,
-  content: '失神しました'
+  content: '失神しました',
+  late_time: 120
 )
 
-Excuse.seed_once(
+Excuse.seed(
   id: 7,
-  content: '突き指しました'
+  content: '突き指しました',
+  late_time: 10
 )
 
-Excuse.seed_once(
+Excuse.seed(
   id: 8,
-  content: 'ナンパされました'
+  content: 'ナンパされました',
+  late_time: 10
 )
 
-Excuse.seed_once(
+Excuse.seed(
   id: 9,
-  content: 'もよおしました'
+  content: 'もよおしました',
+  late_time: 10
 )

--- a/db/migrate/20210113004301_add_late_time_to_excuse.rb
+++ b/db/migrate/20210113004301_add_late_time_to_excuse.rb
@@ -1,0 +1,5 @@
+class AddLateTimeToExcuse < ActiveRecord::Migration[6.0]
+  def change
+    add_column :excuses, :late_time, :integer, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_31_083457) do
+ActiveRecord::Schema.define(version: 2021_01_13_004301) do
 
   create_table "excuse_schedules", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.bigint "schedule_id", null: false
@@ -25,6 +25,7 @@ ActiveRecord::Schema.define(version: 2020_12_31_083457) do
     t.string "content"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "late_time", null: false
   end
 
   create_table "schedules", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|

--- a/spec/factories/excuses.rb
+++ b/spec/factories/excuses.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :excuse do
+    sequence(:content) { |n| "excuse#{n}" }
+    late_time { 1 }
+  end
+end

--- a/spec/models/excuse_spec.rb
+++ b/spec/models/excuse_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe Excuse, type: :model do
+  describe 'バリデーション確認' do
+    let(:excuse) { create(:excuse) }
+    it '内容、遅刻時間があれば有効な状態であること' do
+      expect(excuse).to be_valid
+    end
+
+    it '内容が無ければ無効な状態であること' do
+      excuse.content = nil
+      expect(excuse).to be_invalid
+    end
+
+    it '遅刻時間が無ければ無効な状態であること' do
+      excuse.late_time = nil
+      expect(excuse).to be_invalid
+    end
+
+    it '内容が重複している場合無効な状態であること' do
+      other_excuse = build(:excuse, content: excuse.content)
+      expect(other_excuse).to be_invalid
+    end
+
+    it '内容が重複していない場合有効な状態であること' do
+      other_excuse = build(:excuse)
+      expect(other_excuse).to be_valid
+    end
+  end
+end


### PR DESCRIPTION
# 概要
excuseテーブルにlate_timeカラム追加。
遅刻時間を言い訳ごとに設定し、結果表示ページで合計を表示する。